### PR TITLE
Feature/transmitter dev fixes

### DIFF
--- a/config-chainlink-example.yml
+++ b/config-chainlink-example.yml
@@ -1,0 +1,82 @@
+# =================================================================
+# │         Chainlink Data Streams Transmitter Example            │
+# =================================================================
+#
+# Copy this file to 'config.yml' and fill in your specific details.
+# This file configures which data feeds to monitor and which on-chain
+# contracts to send the data to.
+
+# A list of all unique off-chain Data Streams to subscribe to.
+# Find more feed IDs in the Chainlink documentation.
+feeds:
+  - name: 'ETH/USD'
+    feedId: '0x000359843a543ee2fe414dc14c7e7920ef10f4372990b79d6361cdc0dd1ba782'
+  - name: 'AVAX/USD'
+    feedId: '0x0003735a076086936550bd316b18e5e27fc4f280ee5b6530ce68f5aad404c796'
+
+# --- Default Global Settings ---
+
+# The default chainId to use for transactions if not specified in a target.
+chainId: 43113 # Default to Avalanche Fuji
+
+# The maximum gas limit you are willing to spend on a transaction.
+gasCap: '250000'
+
+# Cron expression defining the data update frequency.
+# This example runs every 30 seconds.
+interval: '*/30 * * * * *'
+
+# The minimum price change percentage to trigger an on-chain update.
+# This example is set to 0.1%
+priceDeltaPercentage: 0.001
+
+# --- Chain & Verifier Definitions ---
+
+# A list of all supported blockchain networks with their RPC URLs.
+chains:
+  - id: 43113
+    name: 'Avalanche Fuji Testnet'
+    currencyName: 'Fuji AVAX'
+    currencySymbol: 'AVAX'
+    currencyDecimals: 18
+    rpc: 'https://api.avax-test.network/ext/bc/C/rpc' # <-- TODO: Replace with your own reliable RPC URL
+    testnet: true
+  - id: 421614
+    name: 'Arbitrum Sepolia'
+    currencyName: 'Arbitrum Sepolia Ether'
+    currencySymbol: 'ETH'
+    currencyDecimals: 18
+    rpc: 'https://sepolia-rollup.arbitrum.io/rpc' # <-- TODO: Replace with your own reliable RPC URL
+    testnet: true
+
+# The addresses of the official Chainlink Verifier contracts on each network.
+verifierAddresses:
+  - chainId: 43113
+    address: '0x2bf612C65f5a4d388E687948bb2CF842FFb8aBB3'
+  - chainId: 421614
+    address: '0x2ff010DEbC1297f19579B4246cad07bd24F2488A'
+
+# --- On-Chain Target Configurations ---
+
+# This section defines which smart contracts to call for each feed on each chain.
+# You can have multiple targets for the same feed.
+targetChains:
+  - chainId: 43113 # Target is on Avalanche Fuji
+    targetContracts:
+      # This configuration sends ETH/USD data to a contract on Fuji
+      - feedId: '0x000359843a543ee2fe414dc14c7e7920ef10f4372990b79d6361cdc0dd1ba782'
+        # TODO: Replace with the address of your deployed contract on Fuji
+        address: '0xYourDataStreamsFeedContractOnFuji' # <-- CHANGED
+        # The name of the function to call on your smart contract
+        functionName: 'updateReport'
+        # The arguments the Transmitter should prepare and send to the function
+        functionArgs: ['reportVersion', 'verifiedReport']
+        # The ABI for the target function, required to encode the transaction
+        abi:
+          - name: 'updateReport'
+            type: 'function'
+            stateMutability: 'nonpayable'
+            inputs:
+              - { "internalType": "uint16", "name": "reportVersion", "type": "uint16" }
+              - { "internalType": "bytes", "name": "verifiedReportData", "type": "bytes" }
+            outputs: []

--- a/config-chainlink-example.yml
+++ b/config-chainlink-example.yml
@@ -11,8 +11,6 @@
 feeds:
   - name: 'ETH/USD'
     feedId: '0x000359843a543ee2fe414dc14c7e7920ef10f4372990b79d6361cdc0dd1ba782'
-  - name: 'AVAX/USD'
-    feedId: '0x0003735a076086936550bd316b18e5e27fc4f280ee5b6530ce68f5aad404c796'
 
 # --- Default Global Settings ---
 

--- a/config-chainlink-verify-example.yml
+++ b/config-chainlink-verify-example.yml
@@ -7,14 +7,14 @@
 # contracts to send the data to.
 
 # -----------------------------------------------------------------
-# ⚠️  OFF-CHAIN VERIFICATION CONFIG (NO LINK NEEDED) ⚠️
+# ✅  ON-CHAIN VERIFICATION CONFIG (LINK-FUNDED FEED) ✅
 # -----------------------------------------------------------------
-# • The transmitter verifies the report off-chain, then calls
-#   `updateReport(uint16 reportVersion, bytes verifiedReportData)`.
-# • Your DataStreamsFeed contract MUST grant the REPORT_VERIFIER role
-#   to the transmitter's EOA (or keystore account) so the call succeeds.
-# • The contract itself does NOT need any LINK balance because fees are
-#   paid by the off-chain verifier, not on-chain.
+# • The transmitter sends the raw report and fee-token parameter to
+#   `verifyAndUpdateReport(bytes unverifiedReportData, bytes parameterPayload)`.
+# • No REPORT_VERIFIER role assignment is required; the function is public.
+# • The DataStreamsFeed contract MUST hold enough LINK (fee token) so the
+#   VerifierProxy can deduct the verification fee from the contract.
+#   Native gas for storage is, as always, paid by the caller.
 # -----------------------------------------------------------------
 
 # A list of all unique off-chain Data Streams to subscribe to.
@@ -77,15 +77,19 @@ targetChains:
         # TODO: Replace with the address of your deployed contract on Fuji
         address: '0xYourDataStreamsFeedContractOnFuji' # <-- CHANGED
         # The name of the function to call on your smart contract
-        functionName: 'updateReport'
+        functionName: 'verifyAndUpdateReport'
         # The arguments the Transmitter should prepare and send to the function
-        functionArgs: ['reportVersion', 'verifiedReport']
+        #   • rawReport          = the unverified payload from the Data Streams websocket
+        #   • parameterPayload   = abi.encode(address feeToken) – produced automatically by the transmitter
+        functionArgs: ['rawReport', 'parameterPayload']
         # The ABI for the target function, required to encode the transaction
         abi:
-          - name: 'updateReport'
+          - name: 'verifyAndUpdateReport'
             type: 'function'
             stateMutability: 'nonpayable'
             inputs:
-              - { "internalType": "uint16", "name": "reportVersion", "type": "uint16" }
-              - { "internalType": "bytes", "name": "verifiedReportData", "type": "bytes" }
+              - { "internalType": "bytes", "name": "unverifiedReportData", "type": "bytes" }
+              - { "internalType": "bytes", "name": "parameterPayload", "type": "bytes" }
             outputs: []
+        # Off-chain verification must run so keep skipVerify false (default)
+        skipVerify: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,13 +14,28 @@ services:
       - DATASTREAMS_CLIENT_SECRET=${DATASTREAMS_CLIENT_SECRET}
     volumes:
       - ./logs:/transmitter/logs
+    # Adding 'depends_on' is good practice to ensure Redis starts first
+    depends_on:
+      - transmitter-redis
+
   transmitter-redis:
-    image: redis:latest
-    command: redis-server --save 60 1 --appendonly yes --requirepass ${REDIS_PASSWORD}
+    # CHANGE 1: Use the correct image that includes all necessary modules
+    image: redis/redis-stack:latest
+    container_name: transmitter-redis
     ports:
       - '6379:6379'
     volumes:
       - ./data:/data
+    # CHANGE 2: Use an inline script to conditionally set the password
+    command: >
+      sh -c "
+        if [ -n \"$REDIS_PASSWORD\" ]; then
+          exec redis-stack-server --requirepass \"$REDIS_PASSWORD\" --save 60 1 --appendonly yes
+        else
+          exec redis-stack-server --save 60 1 --appendonly yes
+        fi
+      "
+
 networks:
   default:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,19 +14,18 @@ services:
       - DATASTREAMS_CLIENT_SECRET=${DATASTREAMS_CLIENT_SECRET}
     volumes:
       - ./logs:/transmitter/logs
-    # Adding 'depends_on' is good practice to ensure Redis starts first
+      - ./config.yml:/transmitter/config.yml
     depends_on:
       - transmitter-redis
 
   transmitter-redis:
-    # CHANGE 1: Use the correct image that includes all necessary modules
     image: redis/redis-stack:latest
     container_name: transmitter-redis
     ports:
       - '6379:6379'
     volumes:
       - ./data:/data
-    # CHANGE 2: Use an inline script to conditionally set the password
+
     command: >
       sh -c "
         if [ -n \"$REDIS_PASSWORD\" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "cron": "^3.5.0",
         "cron-parser": "^5.0.3",
         "cross-env": "^7.0.3",
+        "dotenv": "^16.5.0",
         "express": "^4.19.2",
         "ioredis": "^5.5.0",
         "ioredis-mock": "^8.9.0",
@@ -7267,7 +7268,6 @@
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
       "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "cron": "^3.5.0",
     "cron-parser": "^5.0.3",
     "cross-env": "^7.0.3",
+    "dotenv": "^16.5.0",
     "express": "^4.19.2",
     "ioredis": "^5.5.0",
     "ioredis-mock": "^8.9.0",

--- a/server/services/client.ts
+++ b/server/services/client.ts
@@ -394,6 +394,7 @@ export async function verifyReport(report: StreamReport) {
         bid,
         ask,
         rawReport: report.rawReport,
+        parameterPayload: feeTokenAddressEncoded as Hex,
       };
       logger.info('✅ Report verified', { verifiedReport });
       return verifiedReport;
@@ -433,6 +434,7 @@ export async function verifyReport(report: StreamReport) {
         price,
         marketStatus,
         rawReport: report.rawReport,
+        parameterPayload: feeTokenAddressEncoded as Hex,
       };
       logger.info('✅ Report verified', { verifiedReport });
       return verifiedReport;

--- a/server/services/client.ts
+++ b/server/services/client.ts
@@ -382,6 +382,8 @@ export async function verifyReport(report: StreamReport) {
         verifiedReportData
       );
       const verifiedReport: ReportV3 = {
+        reportVersion,
+        verifiedReport: verifiedReportData as Hex,
         feedId,
         validFromTimestamp,
         observationsTimestamp,
@@ -420,6 +422,8 @@ export async function verifyReport(report: StreamReport) {
         verifiedReportData
       );
       const verifiedReport: ReportV4 = {
+        reportVersion,
+        verifiedReport: verifiedReportData as Hex,
         feedId,
         validFromTimestamp,
         observationsTimestamp,

--- a/server/types.ts
+++ b/server/types.ts
@@ -12,6 +12,8 @@ export type StreamReport = Report & {
 };
 
 export type ReportV3 = {
+  reportVersion: number;
+  verifiedReport: Hex;
   feedId: Hex;
   validFromTimestamp: number;
   observationsTimestamp: number;
@@ -25,6 +27,8 @@ export type ReportV3 = {
 };
 
 export type ReportV4 = {
+  reportVersion: number;
+  verifiedReport: Hex;
   feedId: Hex;
   validFromTimestamp: number;
   observationsTimestamp: number;

--- a/server/types.ts
+++ b/server/types.ts
@@ -24,6 +24,11 @@ export type ReportV3 = {
   bid: bigint;
   ask: bigint;
   rawReport: Hex;
+  /**
+   * Encoded parameter payload (e.g. LINK token address) that must be passed
+   * as the second argument to `verifyAndUpdateReport`.
+   */
+  parameterPayload: Hex;
 };
 
 export type ReportV4 = {
@@ -38,6 +43,11 @@ export type ReportV4 = {
   price: bigint;
   marketStatus: number;
   rawReport: Hex;
+  /**
+   * Encoded parameter payload (e.g. LINK token address) that must be passed
+   * as the second argument to `verifyAndUpdateReport`.
+   */
+  parameterPayload: Hex;
 };
 
 export type Feed = { name: string; feedId: string };


### PR DESCRIPTION
Opening up a PR that aggregates all changes on top of recent rebase - made to support Adrastia's transmitter implementation [DataStreamsFeed.sol](https://github.com/adrastia-oracle/adrastia-chainlink-data-streams/blob/main/contracts/feed/DataStreamsFeed.sol)

_This PR superseeds PR#[23](https://github.com/hackbg/chainlink-datastreams-transmitter/pull/23)__

[6665452](https://github.com/hackbg/chainlink-datastreams-transmitter/pull/23/commits/6665452c0df4a0f370f87328d1f5687a1268d55e): Fixed the local development setup by adding the dotenv package and making the Redis container more stable.
[dd6c46d](https://github.com/hackbg/chainlink-datastreams-transmitter/pull/23/commits/dd6c46d87e2a5a1ee7cfb9e283c1b6f23695e0e6): Allowed the transmitter to recognize changes in config.yml without a full rebuild by adding it to a volume in Docker.
[9fe3951](https://github.com/hackbg/chainlink-datastreams-transmitter/pull/23/commits/9fe3951d46fe680c380d33f6093e3c200fa83de2): Enabled the updateReport function by adding reportVersion and verifiedReport fields to the report types.
[c2fe6ad](https://github.com/hackbg/chainlink-datastreams-transmitter/pull/23/commits/c2fe6add3fee5be98ef7ae413ee9f84759b0efd1): Added a new config.yml file specifically for the quickstart guide.
[0a5b0bc](https://github.com/hackbg/chainlink-datastreams-transmitter/pull/23/commits/0a5b0bcff5b0f62f369bdc14d7664c278031d4f9): Added support for on-chain verification via verifyAndUpdateReport and improved configuration file comments for clarity.
